### PR TITLE
Support for default units in the parser if no unit has been specified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Parse-able strings:
 
 Todo
 ----
-* Add customisable default unit option, e.g. `juration.parse("10", { defaultUnit: 'minutes' }) // returns 600`
 * Parse chrono format i.e. hh:mm:ss
 
 Licence

--- a/juration.js
+++ b/juration.js
@@ -130,17 +130,29 @@
     return output.replace(/\s+$/, '').replace(/^(00:)+/g, '').replace(/^0/, '');
   };
   
-  var parse = function(string) {
+  var parse = function(string, options) {
+    
+    var defaults = {
+      defaultUnit: 'seconds'
+    };
+    
+    var opts = _extend(defaults, options);
+
+    var hasMatch = false;
     
     // returns calculated values separated by spaces
     for(var unit in UNITS) {
       for(var i = 0, mLen = UNITS[unit].patterns.length; i < mLen; i++) {
         var regex = new RegExp("((?:\\d+\\.\\d+)|\\d+)\\s?(" + UNITS[unit].patterns[i] + "s?(?=\\s|\\d|\\b))", 'gi');
+        hasMatch = hasMatch || regex.test(string);
         string = string.replace(regex, function(str, p1, p2) {
           return " " + (p1 * UNITS[unit].value).toString() + " ";
         });
       }
     }
+    
+
+    if (!hasMatch && !isNaN(string) && string.trim() != '') return parse(string + opts.defaultUnit, opts);
     
     var sum = 0,
         numbers = string

--- a/test/index.html
+++ b/test/index.html
@@ -73,6 +73,17 @@ $(function(){
     }
   });
   
+  test("parsing when no units are supplied", function() {
+    var parsed = juration.parse('3600');
+    equal(parsed, 3600, "We expect '3600' to be 3600");
+
+    var parsed = juration.parse('3600', {defaultUnit: 'seconds'});
+    equal(parsed, 3600, "We expect '3600' to be 3600");
+
+    var parsed = juration.parse('90', {defaultUnit: 'minutes'});
+    equal(parsed, 90 * MINUTE, "We expect '90' to be 5400");
+    });
+
   test("stringifying seconds to chrono natural language strings", function() {
     var testCases = [
       [5, "5"],


### PR DESCRIPTION
Allows the parser to assume a certain unit if no units were specified in the input string.
