### PR TITLE
In Micro-format Months & Minutes are the same

### DIFF
--- a/juration.js
+++ b/juration.js
@@ -65,7 +65,7 @@
       value: 2628000,
       formats: {
         'chrono': ':',
-        'micro':  'm',
+        'micro':  'M',
         'short':  'mth',
         'long':   'month'
       }


### PR DESCRIPTION
In Micro-format Months & Minutes are the same. They are both lower-case m.
I'd propose to make Microformat months uppercase, so it's distinguishable.